### PR TITLE
Update for jlab 1.0

### DIFF
--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -4,7 +4,7 @@ A JupyterLab extension for rendering {{cookiecutter.mimetype_name}} files.
 
 ## Prerequisites
 
-* JupyterLab
+* JupyterLab 1.0 or later
 
 ## Installation
 

--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -5,6 +5,7 @@
   "author": "{{cookiecutter.author_name}} <{{cookiecutter.author_email}}>",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "style": "style/index.css",
   "keywords": [
     "jupyter",
     "jupyterlab",
@@ -18,7 +19,7 @@
     "mimeExtension": true
   },
   "scripts": {
-    "clean": "rimraf lib",
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
     "build": "tsc",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w",
@@ -28,11 +29,11 @@
     "extension:disable": "jupyter labextension disable {{cookiecutter.extension_name}}"
   },
   "dependencies": {
-    "@jupyterlab/rendermime-interfaces": "^1.0.0",
+    "@jupyterlab/rendermime-interfaces": "^1.3.0",
     "@phosphor/widgets": "^1.5.0"
   },
   "devDependencies": {
-    "rimraf": "^2.6.2",
-    "typescript": "~2.9.2"
+    "rimraf": "^2.6.3",
+    "typescript": "~3.5.2"
   }
 }

--- a/{{cookiecutter.extension_name}}/src/index.ts
+++ b/{{cookiecutter.extension_name}}/src/index.ts
@@ -6,8 +6,6 @@ import { JSONObject } from '@phosphor/coreutils';
 
 import { Widget } from '@phosphor/widgets';
 
-import '../style/index.css';
-
 /**
  * The default mime type for the extension.
  */

--- a/{{cookiecutter.extension_name}}/tsconfig.json
+++ b/{{cookiecutter.extension_name}}/tsconfig.json
@@ -1,14 +1,23 @@
 {
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
     "declaration": true,
-    "lib": ["es2015", "dom"],
-    "module": "commonjs",
+    "esModuleInterop": true,
+    "incremental": true,
+    "jsx": "react",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
+    "noImplicitAny": true,
     "noUnusedLocals": true,
-    "outDir": "./lib",
-    "target": "es2015",
+    "outDir": "lib",
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "sourceMap": true,
     "strict": true,
+    "target": "es2017",
     "types": []
   },
   "include": ["src/*"]


### PR DESCRIPTION
1. Remove the style import, relying on jlab to pull in the style css from the package.json style field.
2. Update the typescript version and compile options.

I haven't tested this yet...