### PR TITLE
Change default rank from 0 to 100

### DIFF
--- a/{{cookiecutter.python_name}}/src/index.ts
+++ b/{{cookiecutter.python_name}}/src/index.ts
@@ -56,7 +56,7 @@ export const rendererFactory: IRenderMime.IRendererFactory = {
 const extension: IRenderMime.IExtension = {
   id: '{{cookiecutter.labextension_name}}:plugin',
   rendererFactory,
-  rank: 0,
+  rank: 100,
   dataType: '{{ cookiecutter.data_format }}',
   fileTypes: [
     {


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/9901 using 100 as default rank value to match the hard coded value:
https://github.com/jupyterlab/jupyterlab/blob/9850b1a0461ae7d32374ca970185bdd12029fa62/packages/rendermime/src/registry.ts#L220-L222