### PR TITLE
Use production build for prebuilt extension

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -73,7 +73,7 @@ try:
         npm_builder,
         get_data_files
     )
-    builder = npm_builder(HERE, build_cmd="build", npm=["jlpm"])
+    builder = npm_builder(HERE, build_cmd="build:prod", npm=["jlpm"])
     cmdclass = wrap_installers(pre_develop=builder, ensured_targets=ensured_targets)
 
     setup_args['cmdclass'] = cmdclass


### PR DESCRIPTION
Quick fix syncing with https://github.com/jupyterlab/extension-cookiecutter-ts/pull/98.

On a related note, I wonder if `build:prod` should also runs `clean:labextension` (but this is probably for discussion in the main cookiecutter).

Edit: I am not confident if this is the way forward; maybe `setup.py` needs a more general sync with main extension cookiecutter, the scripts diverged quite a bit now.